### PR TITLE
fix(Docker): Always redirect to index.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,6 @@ WORKDIR /usr/share/nginx/html
 
 COPY --from=build /build/build .
 COPY LICENSE.md .
+
+# redirect to index.html if the file or directory isn't found
+RUN sed -i "s/index  index.html index.htm;/index  index.html index.htm;\n        try_files \$uri \$uri\/ \/index.html?\$args;/" /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
As to not clutter the root directory of this project I haven't added an nginx config file and instead modified the default nginx file to contain the catch to redirect to `index.html`.

Fixes #16 

Example New Docker Deployment: https://nativedb.spyral.dev/natives