### PR TITLE
Feat/ts gen

### DIFF
--- a/src/code-generation/TSCodeGenerator.ts
+++ b/src/code-generation/TSCodeGenerator.ts
@@ -1,0 +1,150 @@
+import _ from 'lodash'
+import CodeGeneratorBase, { CodeGeneratorBaseSettings } from './CodeGeneratorBase'
+import { CodeGenNative, CodeGenParam, CodeGenType } from './ICodeGenerator'
+import { toPascalCase } from '../common'
+
+export interface TSCodeGeneratorSettings extends CodeGeneratorBaseSettings {
+  generateComments: boolean
+  useNativeTypes: boolean
+  includes: string[]
+  invokeFunction: string
+  invokeSupportsVoid: boolean
+  oneLineFunctions: boolean
+  includeNdbLinks: boolean
+}
+
+export function convertTypeToTS(type: string, useNativeTypes: boolean) {
+  type = type.replaceAll("*", "").replaceAll("const", "").trim()
+
+  switch (type) {
+    case 'int': return 'number'
+    case 'float': return 'number'
+    case 'char': return 'string'
+    case 'BOOL': return 'boolean'
+    case 'Any': return 'any'
+    case 'Object': type = 'ObjectEntity'; break;
+  }
+
+  if (!useNativeTypes) {
+    return type
+  }
+
+  switch (type) {
+    case 'Hash': return 'number | string'
+    case 'Ped': return 'number'
+    case 'Vehicle': return 'number'
+    case 'Blip': return 'number'
+    case 'Cam': return 'number'
+    case 'ObjectEntity': return 'number'
+    case 'Player': return 'number'
+    case 'Entity': return 'number'
+    case 'ScrHandle': return 'number'
+    case 'FireId': return 'number'
+    case 'Pickup': return 'number'
+    case 'Interior': return 'number'
+    default: return type
+  }
+}
+
+export default
+  class TSCodeGenerator extends CodeGeneratorBase<TSCodeGeneratorSettings> {
+  start(): this {
+    return super.start()
+      .writeComment(`Generated on ${new Date().toLocaleString()}`)
+      .writeComment(`${window.location.origin}`)
+      .writeBlankLine()
+  }
+
+  end(): this {
+    return this
+  }
+
+  transformBaseType(type: string): string {
+    return convertTypeToTS(type, this.settings.useNativeTypes);
+  }
+
+  private transformReturnType(type: string): string {
+    switch (type) {
+      case 'Vector2':
+        return 'number[]'
+      case 'Vector3':
+        return 'number[]'
+      case 'Vector4':
+        return 'number[]'
+      case 'string | number':
+        return 'number'
+    }
+    return type
+  }
+
+  private formatParam({ name, type }: CodeGenParam): string {
+    if (name === "var") name = "variable"
+    return `${name}: ${this.formatType(type)}`
+  }
+
+  addNative(native: CodeGenNative): this {
+    const name = toPascalCase(native.name)
+    const params = native.params.map((param) => this.formatParam(param)).join(', ')
+    const invokeParams = [native.hash, ...native.params.map(this.formatInvokeParam)].join(', ')
+    const returnType = this.transformReturnType(this.formatType(native.returnType))
+    const returnString = returnType === 'void'
+      ? ''
+      : 'return '
+    const invokeReturn = (returnType === 'void') ? '' : `<${returnType}>`
+    const invoker = this.settings.invokeFunction
+    const link = `${window.location.origin}/natives/${native.hash}`
+
+    return this
+      .conditional(this.settings.generateComments, gen => gen.writeComment(native.comment))
+      .conditional(this.settings.generateComments && this.settings.includeNdbLinks && !!native.comment, gen => gen.writeComment(' '))
+      .conditional(this.settings.includeNdbLinks, gen => gen.writeComment(link))
+      .writeLine(`function ${name}(${params}): ${returnType}`)
+      .pushBranch(this.settings.oneLineFunctions)
+      .writeLine(`${returnString}${invoker}${invokeReturn}(${invokeParams});`)
+      .popBranchWithComment(`${native.hash} ${native.jhash} ${native.build ? `b${native.build}` : ''}`)
+  }
+
+  pushNamespace(name: string): this {
+    return this
+  }
+
+  popNamespace(): this {
+    return this
+  }
+
+  protected formatComment(comment: string): string {
+    return `// ${comment}`
+  }
+
+  protected getOpeningBracket(): string | null {
+    return '{'
+  }
+
+  protected getClosingBracket(): string | null {
+    return '}'
+  }
+
+  private formatType(type: CodeGenType): string {
+    let { baseType } = type
+
+    return `${baseType}`
+  }
+
+  private formatInvokeParam({ name, type }: CodeGenParam): string {
+    if (name === "var") name = "variable"
+
+    switch (type.baseType) {
+      case 'Vector2':
+        return `${name}.x, ${name}.y`
+      case 'Vector3':
+        return `${name}.x, ${name}.y, ${name}.z`
+      case 'Vector4':
+        return `${name}.x, ${name}.y, ${name}.z, ${name}.w`
+      case 'number | string':
+      case 'Hash':
+        return `toHash(${name})`
+    }
+
+    return name
+  }
+}

--- a/src/code-generation/TSCodeGenerator.ts
+++ b/src/code-generation/TSCodeGenerator.ts
@@ -134,8 +134,6 @@ export default
   private formatInvokeParam({ name, type }: CodeGenParam, convertHashes: boolean): string {
     if (name === "var") name = "variable"
 
-    console.log(convertHashes);
-
     switch (type.baseType) {
       case 'Vector2':
         return `${name}.x, ${name}.y`

--- a/src/code-generation/index.ts
+++ b/src/code-generation/index.ts
@@ -10,3 +10,6 @@ export * from './NativeExporter'
 
 export { default as RustCodeGenerator } from './RustCodeGenerator'
 export * from './RustCodeGenerator'
+
+export { default as TSCodeGenerator } from './TSCodeGenerator'
+export * from './TSCodeGenerator'

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -27,6 +27,6 @@ export const buildDate: string = preval`module.exports = new Date().toString()`
 
 export { default as getOverlayAlpha } from './getOverlayAlpha'
 
-export function toPascalCase(name: string): string {
-  return name.toLocaleLowerCase().split('_').map((part, i) => upperFirst(part)).join('')
+export function toPascalCase(name: string, joinChar = ''): string {
+  return name.toLocaleLowerCase().split('_').map((part, i) => upperFirst(part)).join(joinChar)
 }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
+import { upperFirst } from 'lodash'
 import preval from 'preval.macro'
 
 export function createShareUrl(path: string) {
@@ -26,3 +27,6 @@ export const buildDate: string = preval`module.exports = new Date().toString()`
 
 export { default as getOverlayAlpha } from './getOverlayAlpha'
 
+export function toPascalCase(name: string): string {
+  return name.toLocaleLowerCase().split('_').map((part, i) => upperFirst(part)).join('')
+}

--- a/src/components/AppBar/SettingsDrawer.tsx
+++ b/src/components/AppBar/SettingsDrawer.tsx
@@ -26,7 +26,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   }, [dispatch])
 
   const handleListDisplayModeChanged = useCallback((_: unknown, value: unknown) => {
-    if (value === 'C' || value === 'UML') {
+    if (value === 'C' || value === 'UML' || value === 'TS') {
       dispatch(setSettings({
         nativeDisplayMode: value
       }))
@@ -39,9 +39,21 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     }))
   }, [dispatch])
 
+  const handleNativeTypesChanged = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setSettings({
+      nativeTypes: e.target.checked
+    }))
+  }, [dispatch])
+
+  const handleCompactVectorsChanged = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setSettings({
+      compactVectors: e.target.checked
+    }))
+  }, [dispatch])
+
   return (
     <Drawer
-      anchor={smallDisplay ? 'bottom' : 'right' }
+      anchor={smallDisplay ? 'bottom' : 'right'}
       open={open}
       onClose={onClose}
       PaperProps={{
@@ -50,10 +62,10 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         }
       }}
     >
-      <Box 
-        sx={{ 
-          display: 'flex', 
-          alignItems: 'center', 
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
           justifyContent: 'space-between',
           p: 2
         }}
@@ -121,9 +133,23 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <ToggleButton value="UML">
                 UML Style
               </ToggleButton>
+              <ToggleButton value="TS">
+                TypeScript
+              </ToggleButton>
             </ToggleButtonGroup>
 
-            {settings.nativeDisplayMode === 'UML' && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={settings.compactVectors}
+                  onChange={handleCompactVectorsChanged}
+                />
+              }
+              sx={{ userSelect: 'none' }}
+              label="Compact Vectors"
+            />
+
+            {(settings.nativeDisplayMode === 'UML' || settings.nativeDisplayMode === 'TS') && (
               <FormControlLabel
                 control={
                   <Checkbox
@@ -135,12 +161,27 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 label="Display void return type"
               />
             )}
+
+            {settings.nativeDisplayMode === 'TS' && (
+              <Fragment>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={settings.nativeTypes}
+                      onChange={handleNativeTypesChanged}
+                    />
+                  }
+                  sx={{ userSelect: 'none' }}
+                  label="Use Native Types"
+                />
+              </Fragment>
+            )}
           </div>
           <div>
             <Typography variant="body1" gutterBottom>
               Special Data
             </Typography>
-            <LocalFileUpload 
+            <LocalFileUpload
               storeAs="special.json"
               label="special.json"
               helpText={(

--- a/src/components/NativeDefinition/NativeDefinition.tsx
+++ b/src/components/NativeDefinition/NativeDefinition.tsx
@@ -6,6 +6,8 @@ import CopyableText from '../CopyableText'
 import NativeParamsEx from '../NativeParamsEx'
 import NativeParams from '../NativeParams'
 import { useSettings } from '../../hooks'
+import { toPascalCase } from '../../common'
+import { convertTypeToTS } from '../../code-generation'
 
 export interface NativeDefinitionProps extends Omit<TypographyProps, 'children'> {
   name         : string
@@ -16,8 +18,13 @@ export interface NativeDefinitionProps extends Omit<TypographyProps, 'children'>
 }
 
 function NativeDefinition({ name, params, returnType, sx, noWrap = false, nameCopyable = true, ...rest }: NativeDefinitionProps) {
-  const { nativeDisplayMode, displayVoidReturnType } = useSettings()
-  const nameWithBreaks = useMemo(() => name.replace(/_/g, '_\u200b'), [name])
+  const { nativeDisplayMode, nativeTypes, displayVoidReturnType } = useSettings()
+  const nameWithBreaks = useMemo(() => {
+    if (nativeDisplayMode === 'TS') {
+      return toPascalCase(name)
+    }
+    return name.replace(/_/g, '_\u200b')
+  }, [name, nativeDisplayMode])
   const { extensions } = useTheme()
   
     return (
@@ -50,9 +57,9 @@ function NativeDefinition({ name, params, returnType, sx, noWrap = false, nameCo
         ) : (
           <NativeParamsEx params={params} />
         )}
-        {(nativeDisplayMode === 'UML' && (displayVoidReturnType || (returnType !== 'void' && returnType !== 'VOID'))) && (
+        {((nativeDisplayMode === 'UML' || nativeDisplayMode === 'TS') && (displayVoidReturnType || (returnType !== 'void' && returnType !== 'VOID'))) && (
           <Box component="span" sx={{ color: extensions.symbolColor }}>
-            {':'}&nbsp;<NativeType popover={!noWrap} type={returnType} />
+            {':'}&nbsp;<NativeType popover={!noWrap} type={nativeDisplayMode === 'TS' ? convertTypeToTS(returnType, nativeTypes) : returnType} />
           </Box>
         )}
       </Typography>

--- a/src/components/NativeDefinition/NativeDefinition.tsx
+++ b/src/components/NativeDefinition/NativeDefinition.tsx
@@ -21,7 +21,7 @@ function NativeDefinition({ name, params, returnType, sx, noWrap = false, nameCo
   const { nativeDisplayMode, nativeTypes, displayVoidReturnType } = useSettings()
   const nameWithBreaks = useMemo(() => {
     if (nativeDisplayMode === 'TS') {
-      return toPascalCase(name)
+      return toPascalCase(name, '\u200b')
     }
     return name.replace(/_/g, '_\u200b')
   }, [name, nativeDisplayMode])

--- a/src/components/NativeParams/NativeParams.tsx
+++ b/src/components/NativeParams/NativeParams.tsx
@@ -3,14 +3,18 @@ import React, { Fragment } from 'react'
 import { useSettings } from '../../hooks'
 import { NativeParam } from '../../store'
 import NativeType from '../NativeType'
+import { convertTypeToTS } from '../../code-generation'
+import { compactParams } from '../../code-generation/CodeGeneratorBase'
 
 export interface NativeParamsProps extends Omit<BoxProps, 'children'> {
   params: NativeParam[]
 }
 
 export default function NativeParams({ params, ...rest }: NativeParamsProps) {
-  const { nativeDisplayMode } = useSettings()
+  const { nativeDisplayMode, nativeTypes, compactVectors } = useSettings()
   const { extensions } = useTheme()
+
+  params = compactParams(params, compactVectors)
 
   return (
     <Box component="span" sx={{ color: extensions.symbolColor }} {...rest}>
@@ -30,6 +34,12 @@ export default function NativeParams({ params, ...rest }: NativeParamsProps) {
             <Fragment>
               :&nbsp;
               <NativeType type={type} />
+            </Fragment>
+          )}
+          {(nativeDisplayMode === 'TS') && (
+            <Fragment>
+              :&nbsp;
+              <NativeType type={convertTypeToTS(type, nativeTypes)} />
             </Fragment>
           )}
           {((index + 1) !== params.length) && ', '}

--- a/src/components/NativeParamsEx/NativeParamsEx.tsx
+++ b/src/components/NativeParamsEx/NativeParamsEx.tsx
@@ -4,14 +4,18 @@ import { useSettings } from '../../hooks'
 import { NativeParam } from '../../store'
 import NativeType from '../NativeType'
 import NativeValue from '../NativeValue'
+import { convertTypeToTS, TSCodeGenerator } from '../../code-generation'
+import { compactParams } from '../../code-generation/CodeGeneratorBase'
 
 export interface NativeParamsExProps extends Omit<BoxProps, 'children'> {
   params: NativeParam[]
 }
 
 export default function NativeParamsEx({ params, ...rest }: NativeParamsExProps) {
-  const { nativeDisplayMode } = useSettings()
+  const { nativeDisplayMode, nativeTypes, compactVectors } = useSettings()
   const { extensions } = useTheme()
+
+  params = compactParams(params, compactVectors)
 
   return (
     <Box component="span" sx={{ color: extensions.symbolColor }} {...rest}>
@@ -29,10 +33,10 @@ export default function NativeParamsEx({ params, ...rest }: NativeParamsExProps)
             <Box component="span" sx={{ color: extensions.parameterColor }}>
               {name}
             </Box>
-            {(nativeDisplayMode === 'UML') && (
+            {(nativeDisplayMode === 'UML' || nativeDisplayMode === 'TS') && (
               <Fragment>
                 :&nbsp;
-                <NativeType type={type} popover />
+                <NativeType type={nativeDisplayMode === 'TS' ? convertTypeToTS(type, nativeTypes) : type} popover />
               </Fragment>
             )}
             {defaultValue && (

--- a/src/pages/GenerateCodePage/GenerateCodePage.tsx
+++ b/src/pages/GenerateCodePage/GenerateCodePage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import CPlusPlus from './CPlusPlus'
 import CSharpEnum from './CSharpEnum'
 import Rust from './Rust'
+import TypeScript from './TypeScript'
 
 function GenerateCodePage() {
   const { language = 'cpp' } = useParams<{ language: string }>()
@@ -27,6 +28,7 @@ function GenerateCodePage() {
               <Tab label="C++" value="cpp" />
               <Tab label="Rust" value="rs" />
               <Tab label="C# Enum" value="cs" />
+              <Tab label="TS" value="ts" />
               <Tab label="SHV.NET" value="shvdn" />
               <Tab label="RPH" value="rph" />
             </TabList>
@@ -39,6 +41,9 @@ function GenerateCodePage() {
             </TabPanel>
             <TabPanel value="cs">
               <CSharpEnum />
+            </TabPanel>
+            <TabPanel value="ts">
+              <TypeScript />
             </TabPanel>
             <TabPanel value="shvdn">
               Soon&trade;

--- a/src/pages/GenerateCodePage/TypeScript.tsx
+++ b/src/pages/GenerateCodePage/TypeScript.tsx
@@ -19,7 +19,8 @@ export default function CPlusPlus() {
         invokeFunction    : '_in',
         invokeSupportsVoid: false,
         oneLineFunctions  : true,
-        includeNdbLinks   : false
+        includeNdbLinks   : false,
+        convertHashes     : true
       }}
       options={[
         {
@@ -46,6 +47,11 @@ export default function CPlusPlus() {
           type : 'boolean',
           label: 'One Line Functions',
           prop : 'oneLineFunctions'
+        },
+        {
+          type : 'boolean',
+          label: 'Convert Hashes (String -> Hash)',
+          prop : 'convertHashes'
         },
       ]}
       advancedOptions={[

--- a/src/pages/GenerateCodePage/TypeScript.tsx
+++ b/src/pages/GenerateCodePage/TypeScript.tsx
@@ -3,7 +3,7 @@ import { TSCodeGenerator } from '../../code-generation'
 import Language from './Language'
 
 
-export default function CPlusPlus() {
+export default function TypeScript() {
   return (
     <Language
       name="ts"

--- a/src/pages/GenerateCodePage/TypeScript.tsx
+++ b/src/pages/GenerateCodePage/TypeScript.tsx
@@ -6,7 +6,7 @@ import Language from './Language'
 export default function TypeScript() {
   return (
     <Language
-      name="ts"
+      name="typescript"
       extension="ts"
       generator={TSCodeGenerator}
       defaultSettings={{

--- a/src/pages/GenerateCodePage/TypeScript.tsx
+++ b/src/pages/GenerateCodePage/TypeScript.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { TSCodeGenerator } from '../../code-generation'
+import Language from './Language'
+
+
+export default function CPlusPlus() {
+  return (
+    <Language
+      name="ts"
+      extension="ts"
+      generator={TSCodeGenerator}
+      defaultSettings={{
+        indentation       : '  ',
+        lineEnding        : 'lf',
+        compactVectors    : true,
+        generateComments  : true,
+        useNativeTypes    : false,
+        includes          : [],
+        invokeFunction    : '_in',
+        invokeSupportsVoid: false,
+        oneLineFunctions  : true,
+        includeNdbLinks   : false
+      }}
+      options={[
+        {
+          type : 'boolean',
+          label: 'Include Comments',
+          prop : 'generateComments'
+        },
+        {
+          type : 'boolean',
+          label: 'Include Links',
+          prop : 'includeNdbLinks'
+        },
+        {
+          type : 'boolean',
+          label: 'Native Types',
+          prop : 'useNativeTypes'
+        },
+        {
+          type : 'boolean',
+          label: 'Compact Vectors',
+          prop : 'compactVectors'
+        },
+        {
+          type : 'boolean',
+          label: 'One Line Functions',
+          prop : 'oneLineFunctions'
+        },
+      ]}
+      advancedOptions={[
+        {
+          type   : 'combo',
+          label  : 'Indentation',
+          prop   : 'indentation',
+          options: [
+            { label: 'Tab', value: '\t' },
+            { label: '1 Space', value: ' ' },
+            { label: '2 Spaces', value: '  ' },
+            { label: '4 Spaces', value: '    ' },
+            { label: '8 Spaces', value: '        ' }
+          ]
+        },
+        {
+          type   : 'combo',
+          label  : 'Line Endings',
+          prop   : 'lineEnding',
+          options: [
+            { label: 'LF', value: 'lf' },
+            { label: 'CR-LF', value: 'crlf' }
+          ]
+        },
+        {
+          type : 'string',
+          label: 'Invoke Function',
+          prop : 'invokeFunction'
+        }
+      ]}
+    />
+  )
+}

--- a/src/pages/NativesPage/NativeInfo.tsx
+++ b/src/pages/NativesPage/NativeInfo.tsx
@@ -3,7 +3,7 @@ import { LinkSharp as ShareIcon, OpenInNewSharp as OpenInNewSharpIcon } from '@m
 import _ from 'lodash'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { createShareUrl } from '../../common'
+import { createShareUrl, toPascalCase } from '../../common'
 import { CodeExamples, NativeComment, NativeDefinition, NativeDetails, NativeUsage } from '../../components'
 import { useCopyToClipboard, useIsSmallDisplay, useLastNotNull, useNative, useSettings } from '../../hooks'
 import { NativeSources } from '../../store'
@@ -67,7 +67,7 @@ export default function NativeInfo() {
           variant="h5" 
           component="h1" 
         >
-          {native.name}
+          {settings.nativeDisplayMode === 'TS' ? toPascalCase(native.name) : native.name}
         </Typography>
       </Box>
       <Stack spacing={2}>

--- a/src/store/model/NativeDisplayMode.ts
+++ b/src/store/model/NativeDisplayMode.ts
@@ -1,4 +1,4 @@
 
-type NativeDisplayMode = 'C' | 'UML'
+type NativeDisplayMode = 'C' | 'UML' | 'TS'
 
 export default NativeDisplayMode

--- a/src/store/reducers/settingsReducer.ts
+++ b/src/store/reducers/settingsReducer.ts
@@ -6,6 +6,8 @@ export interface SettingsReducerState {
   theme                : Theme
   sources              : NativeSources[]
   nativeDisplayMode    : NativeDisplayMode
+  nativeTypes          : boolean
+  compactVectors       : boolean
   displayVoidReturnType: boolean
   lightTheme           : string
   darkTheme            : string
@@ -15,6 +17,8 @@ const initialState: SettingsReducerState = {
   theme: 'system',
   sources: [NativeSources.Alloc8or, NativeSources.DottieDot],
   nativeDisplayMode: 'C',
+  nativeTypes: true,
+  compactVectors: false,
   displayVoidReturnType: true,
   lightTheme: 'Default',
   darkTheme: 'Default'


### PR DESCRIPTION
# Description
Adds TypeScript codegen & native display support

## Sample codegen
```ts
// https://alloc8or.re/gta5/doc/enums/ePedType.txt
// Full list of peds by DurtyFree: https://github.com/DurtyFree/gta-v-data-dumps/blob/master/peds.json
function CreatePed(pedType: number, modelHash: number | string, x: number, y: number, z: number, heading: number, isNetwork: boolean, bScriptHostPed: boolean): number { return _in<number>(0xD49F9B0955C367DE, pedType, _ch(modelHash), x, y, z, heading, isNetwork, bScriptHostPed); } // 0xD49F9B0955C367DE 0x0389EF71 b323
````

To ensure compatibility with existing FiveM code, strings in place of hashes get converted to numbers.
 `_ch` is the existing CFX JS function converting a string to a hash, however it should be simple to recreate this as needed.

## Other Changes
- Added Compact Vector setting to all display versions
- Added native types setting to TS display


## Screenshots
![image](https://github.com/DottieDot/GTAV-NativeDB/assets/2097064/d5049dd1-aca6-4353-b6c0-8a4bbbdf0576)
![image](https://github.com/DottieDot/GTAV-NativeDB/assets/2097064/a85641ee-e4d3-4e5a-9b38-97ffc7cf2176)

